### PR TITLE
fix bug score computation in semanticcoco.add_annotations

### DIFF
--- a/polimorfo/datasets/semanticcoco.py
+++ b/polimorfo/datasets/semanticcoco.py
@@ -75,7 +75,8 @@ class SemanticCocoDataset(CocoDataset):
                 area = int(maskutils.area(group_mask))
                 if area == 0:
                     continue
-                score = float(np.mean(group_mask * class_probs))
+                segment_probs_mask = group_mask * class_probs
+                score = float(np.mean(segment_probs_mask[segment_probs_mask > 0]))
                 annotation_ids.append(
                     self.add_annotation(img_id, cat_id, polygons, area, bbox, 0,
                                         score))


### PR DESCRIPTION
The computation of segment score in [semanticcoco.add_annotations](https://github.com/fabiofumarola/polimorfo/blob/27599303dc9063ef191bf3681338acf82173f4cb/polimorfo/datasets/semanticcoco.py#L78) takes into account also zero pixels outside the region of interest. Added a filter only for non-zero pixels.